### PR TITLE
Feature for automatically creating database from GraphQL schema

### DIFF
--- a/src/main/java/com/arangodb/graphql/create/ArgumentIndexMapping.java
+++ b/src/main/java/com/arangodb/graphql/create/ArgumentIndexMapping.java
@@ -1,0 +1,60 @@
+package com.arangodb.graphql.create;
+
+import com.arangodb.graphql.schema.ArangoVertexDirective;
+import graphql.schema.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ArgumentIndexMapping {
+
+    private GraphQLFieldDefinition fieldDefinition;
+
+    private List<String> fields;
+
+    private String collection;
+
+    public ArgumentIndexMapping(GraphQLFieldDefinition fieldDefinition){
+        this.fieldDefinition = fieldDefinition;
+        init();
+    }
+
+
+    private void init(){
+
+        fields = new ArrayList<>();
+
+        List<GraphQLArgument> arguments = fieldDefinition.getArguments();
+
+        boolean firstMandatoryArgFound = false;
+        for(GraphQLArgument argument : arguments){
+            if(firstMandatoryArgFound){
+                fields.add(argument.getName());
+            }
+            else {
+                boolean nonNull = GraphQLTypeUtil.isNonNull(argument.getType());
+                if (nonNull) {
+                    firstMandatoryArgFound = true;
+                    fields.add(0, argument.getName());
+                } else {
+                    fields.add(argument.getName());
+                }
+            }
+
+        }
+
+        GraphQLUnmodifiedType type = GraphQLTypeUtil.unwrapAll(fieldDefinition.getType());
+        if(type instanceof GraphQLDirectiveContainer) {
+            ArangoVertexDirective vertexDirective = new ArangoVertexDirective((GraphQLDirectiveContainer)type);
+            this.collection = vertexDirective.getCollection();
+        }
+    }
+
+    public String getCollection() {
+        return collection;
+    }
+
+    public List<String> getFields() {
+        return fields;
+    }
+}

--- a/src/main/java/com/arangodb/graphql/create/DatabaseObjectCreator.java
+++ b/src/main/java/com/arangodb/graphql/create/DatabaseObjectCreator.java
@@ -63,7 +63,11 @@ public class DatabaseObjectCreator {
     public void createDatabase(){
         ArangoDatabase db = arango.db(databaseName);
         if(!db.exists()){
+            logger.info("Auto Create Database {}", databaseName);
             db.create();
+        }
+        else{
+            logger.info("Database {} already exists", databaseName);
         }
     }
 
@@ -90,6 +94,7 @@ public class DatabaseObjectCreator {
 
             String collection = mapping.getCollection();
             if(collection != null){
+                logger.info("Auto Create Index on collection {} for fields {}", collection, mapping.getFields());
                 database.collection(collection).ensureHashIndex(mapping.getFields(), new HashIndexOptions());
             }
 
@@ -106,7 +111,11 @@ public class DatabaseObjectCreator {
         ArangoDatabase database = arango.db(databaseName);
 
         if(!database.collection(name).exists()){
+            logger.info("Auto Create Collection {}:{}", name, collectionType);
             database.collection(name).create(collectionCreateOptions);
+        }
+        else{
+            logger.info("Collection already exists {}:{}", name, collectionType);
         }
 
     }

--- a/src/main/java/com/arangodb/graphql/create/DatabaseObjectCreator.java
+++ b/src/main/java/com/arangodb/graphql/create/DatabaseObjectCreator.java
@@ -1,0 +1,114 @@
+package com.arangodb.graphql.create;
+
+import com.arangodb.ArangoDB;
+import com.arangodb.ArangoDatabase;
+import com.arangodb.entity.CollectionType;
+import com.arangodb.graphql.schema.ArangoEdgeDirective;
+import com.arangodb.graphql.schema.ArangoVertexDirective;
+import com.arangodb.model.CollectionCreateOptions;
+import com.arangodb.model.HashIndexOptions;
+import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+public class DatabaseObjectCreator {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final ArangoDB arango;
+    private final String databaseName;
+    private final GraphQLSchema graphQLSchema;
+
+    public DatabaseObjectCreator(ArangoDB arango, String databaseName, GraphQLSchema graphQLSchema) {
+        this.arango = arango;
+        this.databaseName = databaseName;
+        this.graphQLSchema = graphQLSchema;
+    }
+
+    private List<TypeCollectionMapping> createTypeMappings(){
+
+        List<GraphQLType> types = graphQLSchema.getAllTypesAsList();
+
+        List<TypeCollectionMapping> mappings = new ArrayList<>();
+        types.forEach(type -> {
+            if(type instanceof GraphQLObjectType){
+                GraphQLObjectType objectType = (GraphQLObjectType) type;
+                ArangoVertexDirective vertexDirective = new ArangoVertexDirective(objectType);
+                String collection = vertexDirective.getCollection();
+                if(collection != null){
+                    TypeCollectionMapping mapping = new TypeCollectionMapping(collection);
+
+                    objectType.getFieldDefinitions().forEach(graphQLFieldDefinition -> {
+                        ArangoEdgeDirective arangoEdgeDirective = new ArangoEdgeDirective(graphQLFieldDefinition);
+                        String edgeCollectionName = arangoEdgeDirective.getCollection();
+                        if(edgeCollectionName != null){
+                            mapping.addEdgeCollection(edgeCollectionName);
+                        }
+                    });
+
+                    mappings.add(mapping);
+
+                }
+            }
+        });
+
+        return mappings;
+
+    }
+
+    public void createDatabase(){
+        ArangoDatabase db = arango.db(databaseName);
+        if(!db.exists()){
+            db.create();
+        }
+    }
+
+    public void createCollections(){
+
+        List<TypeCollectionMapping> mappings = createTypeMappings();
+        mappings.forEach(mapping -> {
+            String vertex = mapping.getVertexCollection();
+            createCollection(vertex, CollectionType.DOCUMENT);
+            Set<String> edgeCollections = mapping.getEdgeCollections();
+            edgeCollections.forEach(edgeCollection -> {
+                createCollection(edgeCollection, CollectionType.EDGES);
+            });
+        });
+
+    }
+
+    public void createIndexes(){
+
+        ArangoDatabase database = arango.db(databaseName);
+        GraphQLObjectType queryType = graphQLSchema.getQueryType();
+        queryType.getFieldDefinitions().forEach(graphQLFieldDefinition -> {
+            ArgumentIndexMapping mapping = new ArgumentIndexMapping(graphQLFieldDefinition);
+
+            String collection = mapping.getCollection();
+            if(collection != null){
+                database.collection(collection).ensureHashIndex(mapping.getFields(), new HashIndexOptions());
+            }
+
+        });
+    }
+
+    protected CollectionCreateOptions createCollectionCreateOptions(CollectionType collectionType){
+        return new CollectionCreateOptions().type(collectionType);
+    }
+
+    private void createCollection(String name, CollectionType collectionType) {
+
+        CollectionCreateOptions collectionCreateOptions = createCollectionCreateOptions(collectionType);
+        ArangoDatabase database = arango.db(databaseName);
+
+        if(!database.collection(name).exists()){
+            database.collection(name).create(collectionCreateOptions);
+        }
+
+    }
+
+}

--- a/src/main/java/com/arangodb/graphql/create/TypeCollectionMapping.java
+++ b/src/main/java/com/arangodb/graphql/create/TypeCollectionMapping.java
@@ -1,0 +1,29 @@
+package com.arangodb.graphql.create;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class TypeCollectionMapping {
+
+    private final String vertexCollection;
+
+    private final Set<String> edgeCollections;
+
+    public TypeCollectionMapping(String vertexCollection){
+        this.vertexCollection = vertexCollection;
+        this.edgeCollections = new HashSet<>();
+    }
+
+    public void addEdgeCollection(String edgeCollection){
+        this.edgeCollections.add(edgeCollection);
+    }
+
+
+    public String getVertexCollection() {
+        return vertexCollection;
+    }
+
+    public Set<String> getEdgeCollections() {
+        return edgeCollections;
+    }
+}

--- a/src/test/java/com/arangodb/graphql/create/DatabaseObjectCreatorTest.java
+++ b/src/test/java/com/arangodb/graphql/create/DatabaseObjectCreatorTest.java
@@ -1,0 +1,249 @@
+package com.arangodb.graphql.create;
+
+import com.arangodb.ArangoCollection;
+import com.arangodb.ArangoDB;
+import com.arangodb.ArangoDatabase;
+import com.arangodb.entity.CollectionType;
+import com.arangodb.model.CollectionCreateOptions;
+import com.arangodb.model.HashIndexOptions;
+import graphql.schema.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Arrays;
+
+import static graphql.Scalars.GraphQLString;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DatabaseObjectCreatorTest {
+
+    @Mock
+    private ArangoDB arangoDB;
+
+    @Mock
+    private GraphQLSchema graphQLSchema;
+
+    @Mock
+    private ArangoDatabase arangoDatabase;
+
+    @Mock
+    private GraphQLObjectType mockType;
+
+    @Mock
+    private GraphQLDirective mockDirective;
+
+    @Mock
+    private GraphQLDirective mockEdgeDirective;
+
+    @Mock
+    private GraphQLArgument mockArgument;
+
+    @Mock
+    private ArangoCollection mockCollection;
+
+    @Mock
+    private ArangoCollection mockEdgeCollection;
+
+    @Mock
+    private GraphQLFieldDefinition mockFieldDefinition;
+
+    @Mock
+    private GraphQLArgument mockEdgeArgument;
+
+    @Mock
+    private GraphQLObjectType mockQueryType;
+
+    @Mock
+    private GraphQLFieldDefinition mockQueryFieldDefinition;
+
+    @Mock
+    private GraphQLArgument mockMandatoryArgument;
+
+    @Mock
+    private GraphQLArgument mockOptionalArgument;
+
+    private String databaseName = "myDatabase";
+
+    private String collectionName = "myCollection";
+
+    private String edgeCollectionName = "myEdgeCollection";
+
+    private DatabaseObjectCreator databaseObjectCreator;
+    private String mandatoryArgumentName = "mandatoryArg";
+    private String optionalArgumentName = "optionalArg";
+
+    private void attachVertexDirectiveToMockType() {
+        when(mockType.getDirective("vertex")).thenReturn(mockDirective);
+        when(mockDirective.getArgument("collection")).thenReturn(mockArgument);
+        when(mockArgument.getValue()).thenReturn(collectionName);
+    }
+
+    private void attachEdgeDirectiveToMockType() {
+        attachVertexDirectiveToMockType();
+
+        when(mockFieldDefinition.getDirective("edge")).thenReturn(mockEdgeDirective);
+        when(mockEdgeDirective.getArgument("collection")).thenReturn(mockEdgeArgument);
+        when(mockEdgeArgument.getValue()).thenReturn(edgeCollectionName);
+    }
+
+    @Before
+    public void setup() {
+        //Arango
+        when(arangoDB.db(databaseName)).thenReturn(arangoDatabase);
+        when(arangoDatabase.collection(collectionName)).thenReturn(mockCollection);
+        when(arangoDatabase.collection(edgeCollectionName)).thenReturn(mockEdgeCollection);
+
+        //GraphQL Schema
+        when(graphQLSchema.getAllTypesAsList()).thenReturn(Arrays.asList(mockType));
+        when(graphQLSchema.getQueryType()).thenReturn(mockQueryType);
+        when(mockQueryType.getFieldDefinitions()).thenReturn(Arrays.asList(mockQueryFieldDefinition));
+        when(mockQueryFieldDefinition.getType()).thenReturn(mockType);
+        when(mockMandatoryArgument.getName()).thenReturn(mandatoryArgumentName);
+        when(mockMandatoryArgument.getType()).thenReturn(new GraphQLNonNull(GraphQLString));
+        when(mockOptionalArgument.getName()).thenReturn(optionalArgumentName);
+
+
+        //Type Setup
+        when(mockType.getFieldDefinitions()).thenReturn(Arrays.asList(mockFieldDefinition));
+
+        databaseObjectCreator = new DatabaseObjectCreator(arangoDB, databaseName, graphQLSchema);
+    }
+
+    @Test
+    public void createDatabase() {
+        when(arangoDatabase.exists()).thenReturn(false);
+        databaseObjectCreator.createDatabase();
+        verify(arangoDatabase).create();
+    }
+
+    @Test
+    public void doNotCreateExistingDatabase() {
+        when(arangoDatabase.exists()).thenReturn(true);
+        databaseObjectCreator.createDatabase();
+        verify(arangoDatabase, never()).create();
+    }
+
+    @Test
+    public void createCollectionForVertexDirectiveType() {
+        attachVertexDirectiveToMockType();
+        when(mockCollection.exists()).thenReturn(false);
+
+        databaseObjectCreator.createCollections();
+
+        ArgumentCaptor<CollectionCreateOptions> captor = ArgumentCaptor.forClass(CollectionCreateOptions.class);
+        verify(mockCollection).create(captor.capture());
+        assertThat(captor.getValue().getType(), equalTo(CollectionType.DOCUMENT));
+
+    }
+
+    @Test
+    public void doNotCreateExistingCollectionForVertexDirectiveType() {
+        attachVertexDirectiveToMockType();
+        when(mockCollection.exists()).thenReturn(true);
+
+        databaseObjectCreator.createCollections();
+
+        verify(mockCollection, never()).create(ArgumentMatchers.any(CollectionCreateOptions.class));
+
+    }
+
+    @Test
+    public void doNotCreateCollectionForTypeWithNoDirective() {
+
+        databaseObjectCreator.createCollections();
+        verify(mockCollection, never()).create(ArgumentMatchers.any(CollectionCreateOptions.class));
+
+    }
+
+    @Test
+    public void createCollectionForEdgeDirectiveType() {
+        attachEdgeDirectiveToMockType();
+
+        when(mockEdgeCollection.exists()).thenReturn(false);
+
+        databaseObjectCreator.createCollections();
+
+        ArgumentCaptor<CollectionCreateOptions> captor = ArgumentCaptor.forClass(CollectionCreateOptions.class);
+        verify(mockEdgeCollection).create(captor.capture());
+        assertThat(captor.getValue().getType(), equalTo(CollectionType.EDGES));
+
+    }
+
+    @Test
+    public void doNotCreateExistingCollectionForEdgeDirectiveType() {
+        attachEdgeDirectiveToMockType();
+
+        when(mockEdgeCollection.exists()).thenReturn(true);
+
+        databaseObjectCreator.createCollections();
+
+        verify(mockEdgeCollection, never()).create(ArgumentMatchers.any(CollectionCreateOptions.class));
+
+    }
+
+    @Test
+    public void doNotCreateCollectionForFieldWithNoEdgeDirectiveType() {
+        attachVertexDirectiveToMockType();
+
+        databaseObjectCreator.createCollections();
+
+        verify(mockEdgeCollection, never()).create(ArgumentMatchers.any(CollectionCreateOptions.class));
+
+    }
+
+    @Test
+    public void createIndexes() {
+        attachVertexDirectiveToMockType();
+        when(mockQueryFieldDefinition.getArguments()).thenReturn(Arrays.asList(mockMandatoryArgument, mockOptionalArgument));
+
+        databaseObjectCreator.createIndexes();
+
+        ArgumentCaptor<Iterable<String>> captor = ArgumentCaptor.forClass(Iterable.class);
+
+        verify(mockCollection).ensureHashIndex(captor.capture(), ArgumentMatchers.any(HashIndexOptions.class));
+
+        assertThat(captor.getValue(), contains(mandatoryArgumentName, optionalArgumentName));
+
+    }
+
+    @Test
+    public void createIndexesWithOptionalFirstArg() {
+        attachVertexDirectiveToMockType();
+        when(mockQueryFieldDefinition.getArguments()).thenReturn(Arrays.asList(mockOptionalArgument, mockMandatoryArgument));
+
+        databaseObjectCreator.createIndexes();
+
+        ArgumentCaptor<Iterable<String>> captor = ArgumentCaptor.forClass(Iterable.class);
+
+        verify(mockCollection).ensureHashIndex(captor.capture(), ArgumentMatchers.any(HashIndexOptions.class));
+
+        assertThat(captor.getValue(), contains(mandatoryArgumentName, optionalArgumentName));
+
+    }
+
+    @Test
+    public void createIndexesWithNoMandatoryArgs() {
+        attachVertexDirectiveToMockType();
+        when(mockQueryFieldDefinition.getArguments()).thenReturn(Arrays.asList(mockOptionalArgument));
+
+        databaseObjectCreator.createIndexes();
+
+        ArgumentCaptor<Iterable<String>> captor = ArgumentCaptor.forClass(Iterable.class);
+
+        verify(mockCollection).ensureHashIndex(captor.capture(), ArgumentMatchers.any(HashIndexOptions.class));
+
+        assertThat(captor.getValue(), hasItem(optionalArgumentName));
+
+    }
+
+
+}

--- a/src/test/java/com/arangodb/graphql/create/TypeCollectionMappingTest.java
+++ b/src/test/java/com/arangodb/graphql/create/TypeCollectionMappingTest.java
@@ -1,0 +1,27 @@
+package com.arangodb.graphql.create;
+
+import org.junit.Test;
+
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.*;
+
+public class TypeCollectionMappingTest {
+
+    @Test
+    public void addEdgeCollection() {
+        final String testVertexCollection = "banana";
+        final String testEdgeCollection = "apple";
+        TypeCollectionMapping mapping = new TypeCollectionMapping(testVertexCollection);
+        mapping.addEdgeCollection(testEdgeCollection);
+        assertThat(mapping.getEdgeCollections(), contains(testEdgeCollection));
+        assertThat(mapping.getEdgeCollections().size(), equalTo(1));
+    }
+
+    @Test
+    public void vertexCollection() {
+        final String testVertexCollection = "banana";
+        TypeCollectionMapping mapping = new TypeCollectionMapping(testVertexCollection);
+        assertThat(mapping.getVertexCollection(), equalTo(testVertexCollection));
+    }
+}


### PR DESCRIPTION
Optional feature controlled by arangodb.autoCreate property that when enabled will attempt to create databases, collections and indexes on the configured database server, from the GraphQL schema if they do not exist.