### PR TITLE
Resolve 2 mismatch stubbings in ResultResolverNodeHierarchyTest.java

### DIFF
--- a/src/test/java/com/arangodb/graphql/query/result/resolver/ResultResolverNodeHierarchyTest.java
+++ b/src/test/java/com/arangodb/graphql/query/result/resolver/ResultResolverNodeHierarchyTest.java
@@ -161,6 +161,8 @@ public class ResultResolverNodeHierarchyTest {
         topLevelFieldValues.put("__collection", "Document");
         topLevelFieldValues.put("secondLevelField", 41);
 
+        when(topLevelFieldDefinition.getDirective("edgeTarget")).thenReturn(null);
+        when(resultVertices.get("Document/1")).thenReturn(null);
         //Have an Edge directive
         when(topLevelFieldDefinition.getDirective("edge")).thenReturn(edgeDirective);
         when(edgeDirective.getArgument("collection")).thenReturn(collectionArgument);


### PR DESCRIPTION
We are researchers and analyzed the test doubles (mocks) in the test code of the project. In our analysis of the project, we observed that

+ The `getDirective` method, which is previously stubbed, is executed with the argument "edgeTarget", but this specific argument is not stubbed, resulting in a mismatch stubbing. This mismatch occurs in the test `processWithTraversal`.

+ The `get` method, which is previously stubbed, is executed with the argument "Document/1", but this specific argument is not stubbed, resulting in a mismatch stubbing. This mismatch occurs in the test `processWithTraversal`.

In this pull request, we propose a solution to resolve the mismatch stubbings.

Mismatched stubbing occurs when a mocked method is stubbed with specific arguments in a test but later invoked with different arguments in the code, potentially causing unexpected behavior. Mockito recommends addressing these issues, (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/PotentialStubbingProblem.html)