### PR TITLE
Resolve 1 mismatch stubbing in DatabaseObjectCreatorTest.java

### DIFF
--- a/src/test/java/com/arangodb/graphql/create/DatabaseObjectCreatorTest.java
+++ b/src/test/java/com/arangodb/graphql/create/DatabaseObjectCreatorTest.java
@@ -89,7 +89,7 @@ public class DatabaseObjectCreatorTest {
 
     private void attachEdgeDirectiveToMockType() {
         attachVertexDirectiveToMockType();
-
+        when(mockEdgeDirective.getArgument("direction")).thenReturn(null);
         when(mockFieldDefinition.getDirective("edge")).thenReturn(mockEdgeDirective);
         when(mockEdgeDirective.getArgument("collection")).thenReturn(mockEdgeArgument);
         when(mockEdgeArgument.getValue()).thenReturn(edgeCollectionName);


### PR DESCRIPTION
We are researchers and analyzed the test doubles (mocks) in the test code of the project. In our analysis of the project, we observed that

+ The `getArgument` method, which is previously stubbed in the helper method`attachEdgeDirectiveToMockType`, is executed with the argument "direction", but this specific argument is not stubbed, resulting in a mismatch stubbing. This mismatch occurs in tests, `createCollectionForEdgeDirectiveType` and `doNotCreateExistingCollectionForEdgeDirectiveType` , 

In this pull request, we propose a solution to resolve the mismatch stubbing.

Mismatched stubbing occurs when a mocked method is stubbed with specific arguments in a test but later invoked with different arguments in the code, potentially causing unexpected behavior. Mockito recommends addressing these issues, (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/PotentialStubbingProblem.html)